### PR TITLE
Add shared companies context and company-based interview questions

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -82,13 +82,13 @@ app.post('/api/resume/generate', async (req, res) => {
 
 app.post('/api/interview/questions', async (req, res) => {
   try {
-    const { position, experience } = req.body;
+    const { company, position, experience } = req.body;
 
-    if (!position || !experience) {
+    if (!company || !position || !experience) {
       return res.status(400).json({ error: '모든 필드를 입력해주세요.' });
     }
 
-    const prompt = `${position} 포지션에 대한 면접 질문을 생성해주세요.
+    const prompt = `${company} 기업 ${position} 포지션 면접 질문을 생성해주세요.
 경력: ${experience}
 
 다음 카테고리별로 3개씩 질문을 생성해주세요:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import { CompaniesProvider } from "@/contexts/CompaniesContext";
 
 const queryClient = new QueryClient();
 
@@ -13,13 +14,15 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      <CompaniesProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </CompaniesProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/CompanyManager.tsx
+++ b/src/components/CompanyManager.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
+import { useCompanies, Company } from "@/contexts/CompaniesContext";
 import { 
   Building2, 
   Plus, 
@@ -15,29 +16,10 @@ import {
   X
 } from "lucide-react";
 
-interface Company {
-  id: string;
-  name: string;
-  position: string;
-  keywords: string[];
-}
 
 const CompanyManager = () => {
   const { toast } = useToast();
-  const [companies, setCompanies] = useState<Company[]>([
-    {
-      id: "1",
-      name: "네이버",
-      position: "프론트엔드 개발자",
-      keywords: ["React", "TypeScript", "사용자 경험", "팀워크", "성장"]
-    },
-    {
-      id: "2", 
-      name: "카카오",
-      position: "풀스택 개발자",
-      keywords: ["Vue.js", "Node.js", "혁신", "도전정신", "커뮤니케이션"]
-    }
-  ]);
+  const { companies, setCompanies } = useCompanies();
 
   const [isAdding, setIsAdding] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);

--- a/src/components/InterviewManager.tsx
+++ b/src/components/InterviewManager.tsx
@@ -6,6 +6,14 @@ import { Textarea } from "@/components/ui/textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/hooks/use-toast";
 import { generateInterviewQuestions, getInterviewFeedback } from "@/lib/api";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useCompanies } from "@/contexts/CompaniesContext";
 import { 
   MessageSquare, 
   Wand2, 
@@ -26,7 +34,9 @@ interface Question {
 
 const InterviewManager = () => {
   const { toast } = useToast();
+  const { companies } = useCompanies();
   const [selectedQuestionId, setSelectedQuestionId] = useState<string | null>(null);
+  const [company, setCompany] = useState('');
   const [position, setPosition] = useState('');
   const [experience, setExperience] = useState('');
   const [questions, setQuestions] = useState<Question[]>([]);
@@ -34,12 +44,12 @@ const InterviewManager = () => {
   const selectedQuestion = questions.find(q => q.id === selectedQuestionId);
 
   const handleGenerateQuestions = async () => {
-    if (!position.trim() || !experience.trim()) {
-      toast({ title: '입력 오류', description: '직무와 경력을 입력해주세요.', variant: 'destructive' });
+    if (!company.trim() || !position.trim() || !experience.trim()) {
+      toast({ title: '입력 오류', description: '기업, 직무, 경력을 입력해주세요.', variant: 'destructive' });
       return;
     }
     try {
-      const result = await generateInterviewQuestions(position, experience);
+      const result = await generateInterviewQuestions(company, position, experience);
       const lines = (result.result || result).split('\n').filter((l: string) => l.trim());
       const items = lines.map((line: string, idx: number) => ({
         id: String(idx + 1),
@@ -175,6 +185,16 @@ const InterviewManager = () => {
               질문을 선택하여 답변해보세요
             </CardDescription>
             <div className="space-y-2 pt-4">
+              <Select value={company} onValueChange={setCompany}>
+                <SelectTrigger>
+                  <SelectValue placeholder="기업 선택" />
+                </SelectTrigger>
+                <SelectContent>
+                  {companies.map((c) => (
+                    <SelectItem key={c.id} value={c.name}>{c.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <input
                 className="w-full border rounded p-2 text-sm"
                 placeholder="지원 직무"

--- a/src/contexts/CompaniesContext.tsx
+++ b/src/contexts/CompaniesContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useState } from "react";
+
+export interface Company {
+  id: string;
+  name: string;
+  position: string;
+  keywords: string[];
+}
+
+interface CompaniesContextValue {
+  companies: Company[];
+  setCompanies: React.Dispatch<React.SetStateAction<Company[]>>;
+}
+
+const defaultCompanies: Company[] = [
+  {
+    id: "1",
+    name: "네이버",
+    position: "프론트엔드 개발자",
+    keywords: ["React", "TypeScript", "사용자 경험", "팀워크", "성장"]
+  },
+  {
+    id: "2",
+    name: "카카오",
+    position: "풀스택 개발자",
+    keywords: ["Vue.js", "Node.js", "혁신", "도전정신", "커뮤니케이션"]
+  }
+];
+
+const CompaniesContext = createContext<CompaniesContextValue | null>(null);
+
+export const CompaniesProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [companies, setCompanies] = useState<Company[]>(defaultCompanies);
+  return (
+    <CompaniesContext.Provider value={{ companies, setCompanies }}>
+      {children}
+    </CompaniesContext.Provider>
+  );
+};
+
+export function useCompanies() {
+  const ctx = useContext(CompaniesContext);
+  if (!ctx) throw new Error("useCompanies must be used within CompaniesProvider");
+  return ctx;
+}
+
+export default CompaniesContext;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -28,11 +28,11 @@ export async function getInterviewFeedback(question: string, answer: string) {
   return res.json();
 }
 
-export async function generateInterviewQuestions(position: string, experience: string) {
+export async function generateInterviewQuestions(company: string, position: string, experience: string) {
   const res = await fetch('http://localhost:3001/api/interview/questions', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ position, experience }),
+    body: JSON.stringify({ company, position, experience }),
   });
   if (!res.ok) throw new Error('Failed to generate interview questions');
   return res.json();


### PR DESCRIPTION
## Summary
- add `CompaniesContext` to share saved companies
- wrap application with the new provider
- update `CompanyManager` to use shared context
- expose company list in `InterviewManager` with a dropdown
- include chosen company name when generating interview questions
- adjust API and server endpoint to accept company parameter

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6842fa3cf2688332be57b2d0c94dff2b