### PR TITLE
Add renderWithProviders test utility

### DIFF
--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render, RenderOptions } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { CompaniesProvider } from '@/contexts/CompaniesContext'
+
+const renderWithProviders = (
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) => {
+  const queryClient = new QueryClient()
+
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <CompaniesProvider>
+        <MemoryRouter>{children}</MemoryRouter>
+      </CompaniesProvider>
+    </QueryClientProvider>
+  )
+
+  return render(ui, { wrapper: Wrapper, ...options })
+}
+
+export * from '@testing-library/react'
+export { renderWithProviders }
+

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,8 @@
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+afterEach(() => {
+  cleanup()
+})
+


### PR DESCRIPTION
## Summary
- add `renderWithProviders` helper to include app providers
- initialize cleanup and jest-dom in vitest setup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest --version` *(fails: Need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6845831b0c4c83328e75ab0356ce9a2d