### PR TITLE
Add progress context and update dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import { CompaniesProvider } from "@/contexts/CompaniesContext";
+import { DashboardProvider } from "@/contexts/DashboardContext";
 
 const queryClient = new QueryClient();
 
@@ -14,15 +15,17 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <CompaniesProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Index />} />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </BrowserRouter>
-      </CompaniesProvider>
+      <DashboardProvider>
+        <CompaniesProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<Index />} />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </BrowserRouter>
+        </CompaniesProvider>
+      </DashboardProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/InterviewManager.tsx
+++ b/src/components/InterviewManager.tsx
@@ -1,5 +1,5 @@
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useCompanies } from "@/contexts/CompaniesContext";
+import { useDashboard } from "@/contexts/DashboardContext";
 import { 
   MessageSquare, 
   Wand2, 
@@ -35,6 +36,7 @@ interface Question {
 const InterviewManager = () => {
   const { toast } = useToast();
   const { companies } = useCompanies();
+  const { setInterviews } = useDashboard();
   const [selectedQuestionId, setSelectedQuestionId] = useState<string | null>(null);
   const [company, setCompany] = useState('');
   const [position, setPosition] = useState('');
@@ -42,6 +44,13 @@ const InterviewManager = () => {
   const [questions, setQuestions] = useState<Question[]>([]);
 
   const selectedQuestion = questions.find(q => q.id === selectedQuestionId);
+
+  useEffect(() => {
+    const total = questions.length;
+    const answered = questions.filter(q => q.status !== 'unanswered').length;
+    const progress = total === 0 ? 0 : Math.round((answered / total) * 100);
+    setInterviews({ answered, total, progress });
+  }, [questions, setInterviews]);
 
   const handleGenerateQuestions = async () => {
     if (!company.trim() || !position.trim() || !experience.trim()) {
@@ -60,6 +69,7 @@ const InterviewManager = () => {
       setQuestions(items);
       setSelectedQuestionId(null);
       toast({ title: '생성 완료', description: '면접 질문이 생성되었습니다.' });
+      setInterviews({ answered: 0, total: items.length, progress: 0 });
     } catch (err) {
       console.error(err);
       toast({ title: '오류', description: '질문 생성에 실패했습니다.', variant: 'destructive' });

--- a/src/components/ResumeManager.tsx
+++ b/src/components/ResumeManager.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from "react";
+import { useDashboard } from "@/contexts/DashboardContext";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
@@ -20,6 +21,7 @@ import {
 
 const ResumeManager = () => {
   const { toast } = useToast();
+  const { setResume } = useDashboard();
   const [originalText, setOriginalText] = useState("");
   const [keywords, setKeywords] = useState("");
   const [isAnalyzing, setIsAnalyzing] = useState(false);
@@ -62,6 +64,7 @@ const ResumeManager = () => {
     try {
       const result = await analyzeResume(originalText);
       setFeedback(result.result || result);
+      setResume({ completed: true, progress: 100 });
       toast({
         title: "분석 완료",
         description: "AI 첨삭이 완료되었습니다. 결과를 확인해보세요.",

--- a/src/components/__tests__/InterviewManager.test.tsx
+++ b/src/components/__tests__/InterviewManager.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders, screen, waitFor } from '@/test-utils';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
@@ -19,12 +19,8 @@ vi.mock('@/components/ui/select', () => {
 });
 
 import InterviewManager from '../InterviewManager';
-import { CompaniesProvider } from '@/contexts/CompaniesContext';
 import * as api from '@/lib/api';
 
-function renderWithProviders(ui: React.ReactElement) {
-  return render(<CompaniesProvider>{ui}</CompaniesProvider>);
-}
 
 if (!HTMLElement.prototype.hasPointerCapture) {
   Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', { value: () => {} });

--- a/src/components/__tests__/PersonalInfoForm.test.tsx
+++ b/src/components/__tests__/PersonalInfoForm.test.tsx
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest"
 import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/test-utils'
 import userEvent from '@testing-library/user-event'
 import PersonalInfoForm from '../PersonalInfoForm'
 import { Toaster } from '@/components/ui/toaster'

--- a/src/components/__tests__/ResumeManager.test.tsx
+++ b/src/components/__tests__/ResumeManager.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { renderWithProviders, screen } from '@/test-utils';
 import userEvent from '@testing-library/user-event';
 import ResumeManager from '../ResumeManager';
 import { analyzeResume, generateResume } from '@/lib/api';
@@ -23,7 +23,7 @@ describe('ResumeManager', () => {
   });
 
   it('AI 첨삭 요청 버튼 클릭 시 analyzeResume 호출', async () => {
-    render(<ResumeManager />);
+    renderWithProviders(<ResumeManager />);
     const textarea = screen.getByPlaceholderText(/자기소개서를 입력해주세요/i);
     const text = 'a'.repeat(200);
     await userEvent.type(textarea, text);
@@ -34,7 +34,7 @@ describe('ResumeManager', () => {
   });
 
   it('AI 자기소개서 생성 버튼 클릭 시 generateResume 호출', async () => {
-    render(<ResumeManager />);
+    renderWithProviders(<ResumeManager />);
     const generateTab = screen.getByRole('tab', { name: /신규 생성/ });
     await userEvent.click(generateTab);
     const keywordInput = screen.getByLabelText(/핵심 키워드 입력/);

--- a/src/contexts/DashboardContext.tsx
+++ b/src/contexts/DashboardContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useState } from "react";
+
+export interface ResumeStats {
+  completed: boolean;
+  progress: number;
+}
+
+export interface InterviewStats {
+  answered: number;
+  total: number;
+  progress: number;
+}
+
+interface DashboardContextValue {
+  resume: ResumeStats;
+  setResume: React.Dispatch<React.SetStateAction<ResumeStats>>;
+  interviews: InterviewStats;
+  setInterviews: React.Dispatch<React.SetStateAction<InterviewStats>>;
+}
+
+const defaultResume: ResumeStats = { completed: false, progress: 0 };
+const defaultInterviews: InterviewStats = { answered: 0, total: 0, progress: 0 };
+
+const DashboardContext = createContext<DashboardContextValue | null>(null);
+
+export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [resume, setResume] = useState<ResumeStats>(defaultResume);
+  const [interviews, setInterviews] = useState<InterviewStats>(defaultInterviews);
+
+  return (
+    <DashboardContext.Provider value={{ resume, setResume, interviews, setInterviews }}>
+      {children}
+    </DashboardContext.Provider>
+  );
+};
+
+export function useDashboard() {
+  const ctx = useContext(DashboardContext);
+  if (!ctx) throw new Error("useDashboard must be used within DashboardProvider");
+  return ctx;
+}
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useDashboard } from "@/contexts/DashboardContext";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
@@ -24,12 +25,13 @@ import ExportOptions from "@/components/ExportOptions";
 const Index = () => {
   const [activeTab, setActiveTab] = useState("dashboard");
 
-  // Mock data for demo purposes
+  const { resume, interviews } = useDashboard();
+
   const dashboardStats = {
     personalInfo: { completed: true, progress: 100 },
-    resume: { completed: false, progress: 60 },
+    resume,
     companies: { count: 3, completed: true },
-    interviews: { answered: 7, total: 10, progress: 70 }
+    interviews
   };
 
   return (
@@ -106,7 +108,9 @@ const Index = () => {
                     {dashboardStats.resume.progress}%
                   </div>
                   <Progress value={dashboardStats.resume.progress} className="mt-2" />
-                  <p className="text-xs text-slate-600 mt-2">AI 첨삭 진행중</p>
+                  <p className="text-xs text-slate-600 mt-2">
+                    {dashboardStats.resume.completed ? 'AI 첨삭 완료' : 'AI 첨삭 진행중'}
+                  </p>
                 </CardContent>
               </Card>
 
@@ -135,7 +139,9 @@ const Index = () => {
                     {dashboardStats.interviews.answered}/{dashboardStats.interviews.total}
                   </div>
                   <Progress value={dashboardStats.interviews.progress} className="mt-2" />
-                  <p className="text-xs text-slate-600 mt-2">질문 답변 완료</p>
+                  <p className="text-xs text-slate-600 mt-2">
+                    {dashboardStats.interviews.progress === 100 ? '모든 질문 답변 완료' : '질문 답변 진행중'}
+                  </p>
                 </CardContent>
               </Card>
             </div>

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -3,6 +3,7 @@ import { render, RenderOptions } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import { CompaniesProvider } from '@/contexts/CompaniesContext'
+import { DashboardProvider } from '@/contexts/DashboardContext'
 
 const renderWithProviders = (
   ui: React.ReactElement,
@@ -12,9 +13,11 @@ const renderWithProviders = (
 
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <QueryClientProvider client={queryClient}>
-      <CompaniesProvider>
-        <MemoryRouter>{children}</MemoryRouter>
-      </CompaniesProvider>
+      <DashboardProvider>
+        <CompaniesProvider>
+          <MemoryRouter>{children}</MemoryRouter>
+        </CompaniesProvider>
+      </DashboardProvider>
     </QueryClientProvider>
   )
 


### PR DESCRIPTION
## Summary
- create `DashboardContext` for resume and interview progress
- update `ResumeManager` and `InterviewManager` to update dashboard state
- display live progress in `Index` page dashboard
- wrap tests with `DashboardProvider`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846fd13d7148332b10e689c2465cdea