### PR TITLE
Fix tests for job prep assistant

### DIFF
--- a/src/components/__tests__/CompanyManager.test.tsx
+++ b/src/components/__tests__/CompanyManager.test.tsx
@@ -1,13 +1,8 @@
 import CompanyManager from '../CompanyManager';
-import { CompaniesProvider } from '@/contexts/CompaniesContext';
-import { render, screen } from '@testing-library/react';
+import { renderWithProviders, screen } from '@/test-utils';
 import { expect, describe, it } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-
-function renderWithProviders(ui: React.ReactElement) {
-  return render(<CompaniesProvider>{ui}</CompaniesProvider>);
-}
 
 describe('CompanyManager', () => {
   it('기본 회사 목록이 표시되어야 한다', () => {

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { render, RenderOptions } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
+import { PersonalInfoProvider } from '@/contexts/PersonalInfoContext'
 import { CompaniesProvider } from '@/contexts/CompaniesContext'
+import { DashboardProvider } from '@/contexts/DashboardContext'
 
 const renderWithProviders = (
   ui: React.ReactElement,
@@ -12,6 +14,13 @@ const renderWithProviders = (
 
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <PersonalInfoProvider>
+          <CompaniesProvider>
+            <DashboardProvider>{children}</DashboardProvider>
+          </CompaniesProvider>
+        </PersonalInfoProvider>
+      </MemoryRouter>
     </QueryClientProvider>
   )
 


### PR DESCRIPTION
## Summary
- provide a reusable `renderWithProviders` helper
- use new helper in `CompanyManager` tests

## Testing
- `npx vitest run --reporter json --outputFile vitest-result.json` *(fails to exit, killed)*


------
https://chatgpt.com/codex/tasks/task_e_684793f2a2f08332bdf069eccaf2abcc